### PR TITLE
Update existing trigger feeds on create instead of failing

### DIFF
--- a/actions/event-actions/lib/Database.js
+++ b/actions/event-actions/lib/Database.js
@@ -70,7 +70,19 @@ module.exports = function(dbURL, dbName) {
                     resolve();
                 }
                 else {
-                    reject(common.sendError(err.statusCode, 'error creating cloudant trigger.', err.message));
+                    const errorMsg = 'error creating cloudant trigger.';
+                    if (err.statusCode === 409) {
+                        //trigger already exists so update it
+                        utilsDB.getTrigger(triggerID)
+                        .then(trigger => utilsDB.disableTrigger(triggerID, trigger, 0, 'updating'))
+                        .then(() => utilsDB.getTrigger(triggerID))
+                        .then(trigger => utilsDB.updateTrigger(triggerID, newTrigger, {_rev: trigger._rev}, 0))
+                        .then(() => resolve())
+                        .catch(err => reject(common.sendError(err.statusCode, errorMsg, err.message)));
+                    }
+                    else {
+                        reject(common.sendError(err.statusCode, errorMsg, err.message));
+                    }
                 }
             });
         });


### PR DESCRIPTION
If for some reason a trigger is deleted, but the corresponding feed is not, allow a trigger in the same namespace with the same trigger name to be recreated with the existing feed.

equivalent to https://github.com/apache/openwhisk-package-kafka/pull/360