### PR TITLE
Remove console.{log,error} from most parts of the codebase

### DIFF
--- a/actions/account-actions/create-database.js
+++ b/actions/account-actions/create-database.js
@@ -41,10 +41,8 @@ function createDatabase(cloudant, dbName) {
   return new Promise(function(resolve, reject) {
     cloudant.db.create(dbName, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.log('error', error);
         reject(error);
       }
     });

--- a/actions/account-actions/delete-database.js
+++ b/actions/account-actions/delete-database.js
@@ -39,10 +39,8 @@ function destroyDatabase(cloudant, dbName) {
   return new Promise(function(resolve, reject) {
     cloudant.db.destroy(dbName, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.log('error', error);
         reject(error);
       }
     });

--- a/actions/account-actions/list-all-databases.js
+++ b/actions/account-actions/list-all-databases.js
@@ -34,13 +34,11 @@ function listAllDatabases(cloudant) {
   return new Promise(function(resolve, reject) {
     cloudant.db.list(function(error, response) {
       if (!error) {
-        console.log('success', response);
         //Response is an array and only JSON objects can be passed
         var responseObj = {};
         responseObj.all_databases = response;
         resolve(responseObj);
       } else {
-        console.log('error', error);
         reject(error);
       }
     });

--- a/actions/account-actions/read-database.js
+++ b/actions/account-actions/read-database.js
@@ -38,10 +38,8 @@ function readDatabase(cloudant, dbName) {
   return new Promise(function(resolve, reject) {
     cloudant.db.get(dbName, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.log('error', error);
         reject(error);
       }
     });

--- a/actions/account-actions/read-updates-feed.js
+++ b/actions/account-actions/read-updates-feed.js
@@ -45,10 +45,8 @@ function readUpdatesFeed(cloudant, params) {
   return new Promise(function(resolve, reject) {
     cloudant.updates(params, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.log('error', error);
         reject(error);
       }
     });

--- a/actions/database-actions/create-document.js
+++ b/actions/database-actions/create-document.js
@@ -70,10 +70,8 @@ function insert(cloudantDb, doc, params) {
   return new Promise(function(resolve, reject) {
     cloudantDb.insert(doc, params, function(error, response) {
       if (!error) {
-        console.log("success", response);
         resolve(response);
       } else {
-        console.log("error", error);
         reject(error);
       }
     });

--- a/actions/database-actions/create-query-index.js
+++ b/actions/database-actions/create-query-index.js
@@ -55,10 +55,8 @@ function createIndex(cloudantDb, index) {
   return new Promise(function(resolve, reject) {
     cloudantDb.index(index, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.log('error', error);
         reject(response);
       }
     });

--- a/actions/database-actions/create-update-attachment.js
+++ b/actions/database-actions/create-update-attachment.js
@@ -74,10 +74,8 @@ function insert(cloudantDb, docId, attName, att, contentType, params) {
   return new Promise(function(resolve, reject) {
     cloudantDb.attachment.insert(docId, attName, att, contentType, params, function(error, response) {
       if (!error) {
-        console.log("success", response);
         resolve(response);
       } else {
-        console.log("error", error);
         reject(error);
       }
     });

--- a/actions/database-actions/delete-attachment.js
+++ b/actions/database-actions/delete-attachment.js
@@ -69,10 +69,8 @@ function deleteAttachment(cloudantDb, docId, attName, params) {
   return new Promise(function(resolve, reject) {
     cloudantDb.attachment.destroy(docId, attName, params, function(error, response) {
       if (!error) {
-        console.log("success", response);
         resolve(response);
       } else {
-        console.log("error", error);
         reject(error);
       }
     });

--- a/actions/database-actions/delete-document.js
+++ b/actions/database-actions/delete-document.js
@@ -52,10 +52,8 @@ function destroy(cloudantDb, docId, docRev) {
   return new Promise(function(resolve, reject) {
     cloudantDb.destroy(docId, docRev, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.error('error', error);
         reject(error);
       }
     });

--- a/actions/database-actions/delete-query-index.js
+++ b/actions/database-actions/delete-query-index.js
@@ -60,10 +60,8 @@ function deleteIndexFromDesignDoc(cloudant, docId, indexName, indexType, dbName)
         path : path
       }, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.log('error', error);
         reject(error);
       }
     });

--- a/actions/database-actions/delete-view.js
+++ b/actions/database-actions/delete-view.js
@@ -65,7 +65,6 @@ function deleteViewFromDesignDoc(cloudantDb, docId, viewName, params) {
 
   return getDocument(cloudantDb, docId)
     .then(function(document) {
-        console.log("Got document: " + document);
         delete document.views[viewName];
 
         //Update the design document after removing the view
@@ -77,10 +76,8 @@ function getDocument(cloudantDb, docId) {
   return new Promise(function(resolve, reject) {
     cloudantDb.get(docId, function(error, response) {
       if (!error) {
-        console.log("Got response: " + response);
         resolve(response);
       } else {
-        console.log("Got error: " + error);
         reject(error);
       }
     });
@@ -91,10 +88,8 @@ function insert(cloudantDb, doc, params) {
   return new Promise(function(resolve, reject) {
     cloudantDb.insert(doc, params, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.log('error', error);
         reject(error);
       }
     });

--- a/actions/database-actions/exec-query-find.js
+++ b/actions/database-actions/exec-query-find.js
@@ -57,10 +57,8 @@ function queryIndex(cloudantDb, query) {
   return new Promise(function(resolve, reject) {
     cloudantDb.find(query, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.log('error', error);
         reject(error);
       }
     });

--- a/actions/database-actions/exec-query-search.js
+++ b/actions/database-actions/exec-query-search.js
@@ -65,10 +65,8 @@ function querySearch(cloudantDb, designDocId, designViewName, search) {
   return new Promise(function(resolve, reject) {
     cloudantDb.search(designDocId, designViewName, search, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.log('error', error);
         reject(error);
       }
     });

--- a/actions/database-actions/exec-query-view.js
+++ b/actions/database-actions/exec-query-view.js
@@ -62,10 +62,8 @@ function queryView(cloudantDb, designDocId, designDocViewName, params) {
   return new Promise(function(resolve, reject) {
     cloudantDb.view(designDocId, designDocViewName, params, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.error('error', error);
         reject(error);
       }
     });

--- a/actions/database-actions/list-design-documents.js
+++ b/actions/database-actions/list-design-documents.js
@@ -40,7 +40,6 @@ function main(message) {
 
   //If includeDoc exists and is true, add field to additional params object
   includeDocs = includeDocs.toString().trim().toLowerCase();
-  console.log('includeDocs: ' + includeDocs);
   if(includeDocs === 'true') {
     params.include_docs = 'true';
   }
@@ -55,10 +54,8 @@ function listDesignDocuments(cloudantDb, params) {
   return new Promise(function(resolve, reject) {
     cloudantDb.list(params, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.error("error", error);
         reject(error);
       }
     });

--- a/actions/database-actions/list-documents.js
+++ b/actions/database-actions/list-documents.js
@@ -54,10 +54,8 @@ function listAllDocuments(cloudantDb, params) {
   return new Promise(function(resolve, reject) {
     cloudantDb.list(params, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.error("error", error);
         reject(error);
       }
     });

--- a/actions/database-actions/list-query-indexes.js
+++ b/actions/database-actions/list-query-indexes.js
@@ -40,10 +40,8 @@ function index(cloudantDb) {
   return new Promise(function(resolve, reject) {
     cloudantDb.index(function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.log('error', error);
         reject(error);
       }
     });

--- a/actions/database-actions/manage-bulk-documents.js
+++ b/actions/database-actions/manage-bulk-documents.js
@@ -69,10 +69,8 @@ function bulk(cloudantDb, docs, params) {
       if (!error) {
         var responseDocs = {};
         responseDocs.docs = response;
-        console.log('success', response);
         resolve(responseDocs);
       } else {
-        console.log('Error: ', error);
         reject(error);
       }
     });

--- a/actions/database-actions/read-attachment.js
+++ b/actions/database-actions/read-attachment.js
@@ -67,10 +67,8 @@ function read(cloudantDb, docId, attName, params) {
   return new Promise(function(resolve, reject) {
     cloudantDb.attachment.get(docId, attName, params, function(error, response) {
       if (!error) {
-        console.log("success", response);
         resolve(response);
       } else {
-        console.log("error", error);
         reject(error);
       }
     });

--- a/actions/database-actions/read-changes-feed.js
+++ b/actions/database-actions/read-changes-feed.js
@@ -50,10 +50,8 @@ function changes(cloudant, dbName, params) {
   return new Promise(function(resolve, reject) {
     cloudant.db.changes(dbName, params, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.error('error', error);
         reject(error);
       }
     });

--- a/actions/database-actions/read-document.js
+++ b/actions/database-actions/read-document.js
@@ -55,10 +55,8 @@ function readDocument(cloudantDb, docId, params) {
   return new Promise(function(resolve, reject) {
     cloudantDb.get(docId, params, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.error('error', error);
         reject(error);
       }
     });

--- a/actions/database-actions/update-document.js
+++ b/actions/database-actions/update-document.js
@@ -70,10 +70,8 @@ function insert(cloudantDb, doc, params) {
   return new Promise(function(resolve, reject) {
     cloudantDb.insert(doc, params, function(error, response) {
       if (!error) {
-        console.log('success', response);
         resolve(response);
       } else {
-        console.log('error', error);
         reject(error);
       }
     });

--- a/actions/database-actions/write-document.js
+++ b/actions/database-actions/write-document.js
@@ -112,10 +112,8 @@ function insert(cloudantDb, doc) {
     return new Promise(function(resolve, reject) {
         cloudantDb.insert(doc, function(error, response) {
             if (!error) {
-                console.log('success', response);
                 resolve(response);
             } else {
-                console.log('error', error);
                 reject(error);
             }
         });

--- a/actions/database-actions/write-document.js
+++ b/actions/database-actions/write-document.js
@@ -89,7 +89,6 @@ function insertOrUpdate(cloudantDb, overwrite, doc) {
                                     reject(err);
                                 });
                         } else {
-                            console.error('error', error);
                             reject(error);
                         }
                     }

--- a/actions/event-actions/changesWebAction.js
+++ b/actions/event-actions/changesWebAction.js
@@ -106,7 +106,6 @@ function main(params) {
                 return db.getWorkerID(workers);
             })
             .then((worker) => {
-                console.log('trigger will be assigned to worker ' + worker);
                 newTrigger.worker = worker;
                 return db.createTrigger(triggerID, newTrigger);
             })

--- a/actions/event-actions/lib/common.js
+++ b/actions/event-actions/lib/common.js
@@ -43,11 +43,9 @@ function requestHelper(url, input, method) {
             }
             else {
                 if (response) {
-                    console.log('cloudant: Error invoking whisk action:', response.statusCode, body);
                     reject(body);
                 }
                 else {
-                    console.log('cloudant: Error invoking whisk action:', error);
                     reject(error);
                 }
             }
@@ -132,7 +130,7 @@ function constructObject(data) {
                 jsonObject = JSON.parse(data);
             }
             catch (e) {
-                console.log('error parsing ' + data);
+                console.error('error parsing ' + data);
             }
         }
         if (typeof data === 'object') {


### PR DESCRIPTION
A standard pattern in this package is to print the contents of the
Cloudant response to stdout through console.log before returning it
in to the runtime. This is redundant because OpenWhisk itself provides
methods to record and view the data being passed between actions. It's
also harmful for two reasons:

1. Unneccesarry platform logging. The platform logs for our Cloudant
   instance are captured for compliance reasons. In our workload, we
   were literally paying twice as much for log file parsing as for
   our OpenWhisk processing, as the body of every database document
   was ending up in the logs (and some were quite big)

2. Security. The document bodies ending up in the logs meant that
   log file 'read' permissions were being effectively escalalted
   to ersatz database 'read' permissions. In particular, our
   compliance team could, but shouldn't have been able to, view
   some customer data.

This PR removes all console.log and console.error with the exception
of one (in common.js constructObject). Most of the removals were
required to fix point 2 above though there were some that were pure
simple debug output that could be left in, but were removed based
on point 1. The one instance left was left because without it, there
would have been an empty catch block and I'm not familiar enough with
the code to understand the implications of that here!

I'm happy to revise the PR to reinstate some of the pure debug
outputs if required.